### PR TITLE
requirements: adding chardet==3.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ lxml==3.7.3
 requests==2.14.2
 unicodecsv==0.14.1
 xlrd==1.1.0
+chardet==3.0.4


### PR DESCRIPTION
The analyzer.py also requires chardet, so add this to the requirements file.